### PR TITLE
Add Heroku build manifest for Docker-based deploys

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+run:
+  web: node --require ./polyfill.cjs dist/index.js


### PR DESCRIPTION
## Summary
- add a heroku.yml manifest that points the web process to the existing Dockerfile
- configure the container to launch using the polyfill-aware node command

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db5a111aac832e89a47e34a803a701