### PR TITLE
Extract some testing constants into textFixtures

### DIFF
--- a/test/helpers/testFixtures.ts
+++ b/test/helpers/testFixtures.ts
@@ -7,6 +7,8 @@
  * Shared test data and constants used across test suites.
  */
 
+import type { Intention } from '../../src/types/core.js'
+
 /**
  * Sample vault ID for testing (valid 32-byte hex string with 0x prefix).
  */
@@ -97,3 +99,58 @@ export const TOKEN = '0x1111111111111111111111111111111111111111'
  * Zero address (ETH address).
  */
 export const ZERO = '0x0000000000000000000000000000000000000000'
+
+/**
+ * Creates a mock valid intention object for testing.
+ * Returns a new intention object each time it's called with a fresh expiry timestamp.
+ */
+export const createMockValidIntention = (): Intention => ({
+	action: 'Swap 1,000 USDC for 0.3 WETH with .016 WETH in fees',
+	nonce: 1,
+	expiry: Math.floor(Date.now() / 1000) + 3600, // Expires in 1 hour
+	inputs: [
+		{
+			asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+			amount: '1000.0',
+			chain_id: 1,
+		},
+	],
+	outputs: [
+		{
+			asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+			amount: '0.3',
+			to_external: '0xDB473D9716ac61dc4D4aeA6e4d691239DB84C77D',
+			chain_id: 1,
+		},
+	],
+	totalFee: [
+		{
+			asset: ['WETH'],
+			amount: '0.016',
+		},
+	],
+	proposerTip: [
+		{
+			asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+			amount: '0.01',
+			to: 123, // Some vault ID
+			chain_id: 1,
+		},
+	],
+	agentTip: [
+		{
+			asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+			amount: '0.005',
+			to: 456, // Some other vault ID
+			chain_id: 1,
+		},
+	],
+	protocolFee: [
+		{
+			asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+			amount: '0.001',
+			to: 0, // Oya vault ID
+			chain_id: 1,
+		},
+	],
+})

--- a/test/helpers/testFixtures.ts
+++ b/test/helpers/testFixtures.ts
@@ -72,3 +72,28 @@ export const SAMPLE_INTENTION = {
 	vaultId: TEST_VAULT_ID,
 	signature: '0x' + '0'.repeat(130), // Dummy signature
 }
+
+/**
+ * Test transaction hash for deposits tests.
+ */
+export const TEST_TX = '0xtest-deposit-tx'
+
+/**
+ * Generate test UID for deposits tests.
+ */
+export const TEST_UID = (n: number) => `${TEST_TX}:${n}`
+
+/**
+ * Controller address for deposits tests.
+ */
+export const CTRL = '0xCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCc'
+
+/**
+ * Token address for deposits tests.
+ */
+export const TOKEN = '0x1111111111111111111111111111111111111111'
+
+/**
+ * Zero address (ETH address).
+ */
+export const ZERO = '0x0000000000000000000000000000000000000000'

--- a/test/integration/deposits.db.test.ts
+++ b/test/integration/deposits.db.test.ts
@@ -17,7 +17,13 @@ import {
 	findDepositWithSufficientRemaining,
 	createAssignmentEventTransactional,
 } from '../../src/utils/deposits.js'
-import { TEST_TX, TEST_UID, CTRL, TOKEN, ZERO } from '../helpers/testFixtures.js'
+import {
+	TEST_TX,
+	TEST_UID,
+	CTRL,
+	TOKEN,
+	ZERO,
+} from '../helpers/testFixtures.js'
 
 beforeAll(async () => {
 	await pool.query('DELETE FROM deposits WHERE tx_hash = $1', [TEST_TX])

--- a/test/integration/deposits.db.test.ts
+++ b/test/integration/deposits.db.test.ts
@@ -17,12 +17,7 @@ import {
 	findDepositWithSufficientRemaining,
 	createAssignmentEventTransactional,
 } from '../../src/utils/deposits.js'
-
-const TEST_TX = '0xtest-deposit-tx'
-const TEST_UID = (n: number) => `${TEST_TX}:${n}`
-const CTRL = '0xCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCc'
-const TOKEN = '0x1111111111111111111111111111111111111111'
-const ZERO = '0x0000000000000000000000000000000000000000'
+import { TEST_TX, TEST_UID, CTRL, TOKEN, ZERO } from '../helpers/testFixtures.js'
 
 beforeAll(async () => {
 	await pool.query('DELETE FROM deposits WHERE tx_hash = $1', [TEST_TX])

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -20,59 +20,11 @@ import {
 	ValidationError,
 } from '../src/utils/validator.js'
 import type { Intention } from '../src/types/core.js'
+import { createMockValidIntention } from './helpers/testFixtures.js'
 
 // --- MOCK DATA FOR TESTS ---
 
-const mockValidIntention: Intention = {
-	action: 'Swap 1,000 USDC for 0.3 WETH with .016 WETH in fees',
-	nonce: 1,
-	expiry: Math.floor(Date.now() / 1000) + 3600, // Expires in 1 hour
-	inputs: [
-		{
-			asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
-			amount: '1000.0',
-			chain_id: 1,
-		},
-	],
-	outputs: [
-		{
-			asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-			amount: '0.3',
-			to_external: '0xDB473D9716ac61dc4D4aeA6e4d691239DB84C77D',
-			chain_id: 1,
-		},
-	],
-	totalFee: [
-		{
-			asset: ['WETH'],
-			amount: '0.016',
-		},
-	],
-	proposerTip: [
-		{
-			asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-			amount: '0.01',
-			to: 123, // Some vault ID
-			chain_id: 1,
-		},
-	],
-	agentTip: [
-		{
-			asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-			amount: '0.005',
-			to: 456, // Some other vault ID
-			chain_id: 1,
-		},
-	],
-	protocolFee: [
-		{
-			asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-			amount: '0.001',
-			to: 0, // Oya vault ID
-			chain_id: 1,
-		},
-	],
-}
+const mockValidIntention: Intention = createMockValidIntention()
 
 // --- TEST SUITES ---
 


### PR DESCRIPTION
This PR extracts some constants from tests into `testFixtures.js` per a comment in #48 
https://github.com/oyaprotocol/node/pull/48#discussion_r2476262622

Specifically, it extracts: 
- `TEST_TX`, `TEST_UID`, `CTRL`, `TOKEN`, `ZERO` (from deposits tests)
- `createMockValidIntention()` function (from validator tests)
